### PR TITLE
[bitmoa/mariadb] mariadb-admin socket bitnami fixed path error

### DIFF
--- a/bitmoa/mariadb/Chart.yaml
+++ b/bitmoa/mariadb/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: mariadb
 sources:
 - https://github.com/bitmoa/charts/tree/main/bitmoa/mariadb
-version: 22.0.0
+version: 22.0.1

--- a/bitmoa/mariadb/templates/primary/statefulset.yaml
+++ b/bitmoa/mariadb/templates/primary/statefulset.yaml
@@ -255,7 +255,7 @@ spec:
                   if [[ -f "${MARIADB_ROOT_PASSWORD_FILE:-}" ]]; then
                       password_aux=$(cat "$MARIADB_ROOT_PASSWORD_FILE")
                   fi
-                  mariadb-admin ping -uroot -p"${password_aux}"
+                  mariadb-admin ping -uroot -p"${password_aux}" -h 127.0.0.1
           {{- end }}
           {{- if .Values.primary.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.primary.customLivenessProbe "context" $) | nindent 12 }}
@@ -270,7 +270,7 @@ spec:
                   if [[ -f "${MARIADB_ROOT_PASSWORD_FILE:-}" ]]; then
                       password_aux=$(cat "$MARIADB_ROOT_PASSWORD_FILE")
                   fi
-                  mariadb-admin status -uroot -p"${password_aux}"
+                  mariadb-admin status -uroot -p"${password_aux}" -h 127.0.0.1
           {{- end }}
           {{- if .Values.primary.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.primary.customReadinessProbe "context" $) | nindent 12 }}

--- a/bitmoa/mariadb/templates/secondary/statefulset.yaml
+++ b/bitmoa/mariadb/templates/secondary/statefulset.yaml
@@ -257,7 +257,7 @@ spec:
                   if [[ -f "${MARIADB_MASTER_ROOT_PASSWORD_FILE:-}" ]]; then
                       password_aux=$(cat "$MARIADB_MASTER_ROOT_PASSWORD_FILE")
                   fi
-                  mariadb-admin status -uroot -p"${password_aux}"
+                  mariadb-admin status -uroot -p"${password_aux}" -h 127.0.0.1
           {{- end }}
           {{- if .Values.secondary.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.secondary.customReadinessProbe "context" $) | nindent 12 }}
@@ -272,7 +272,7 @@ spec:
                   if [[ -f "${MARIADB_MASTER_ROOT_PASSWORD_FILE:-}" ]]; then
                       password_aux=$(cat "$MARIADB_MASTER_ROOT_PASSWORD_FILE")
                   fi
-                  mariadb-admin ping -uroot -p"${password_aux}"
+                  mariadb-admin ping -uroot -p"${password_aux}" -h 127.0.0.1
           {{- end }}
           {{- end }}
           {{- if .Values.secondary.resources }}


### PR DESCRIPTION
### Description of the change

MariaDB 차트에서 하드코딩된 소켓 경로를 `/opt/bitnami`에서 `/opt/bitmoa`로 변경하는 수정사항입니다. 이 문제는 Bitnami에서 Bitmoa로 브랜드 변경 과정에서 소켓 경로가 일부 파일에서 제대로 업데이트되지 않아 mariadb-admin 명령어가 잘못된 소켓 경로를 참조하는 이슈를 해결합니다.

### Benefits

- mariadb-admin 명령어가 올바른 소켓 경로를 통해 데이터베이스에 연결할 수 있게 됩니다.
- 관리 작업(상태 확인, 데이터베이스 백업 및 복원)이 정상적으로 작동합니다.
- 브랜드 변경 작업(bitnami -> bitmoa)의 일관성을 유지합니다.

### Possible drawbacks

- 기존에 `/opt/bitnami` 경로를 직접 참조하는 커스텀 스크립트가 있는 경우 영향을 받을 수 있습니다.

### Applicable issues
<img width="1274" height="286" alt="image" src="https://github.com/user-attachments/assets/f4839265-3c82-4c89-8d03-368cc92e73f7" />

### Additional information

이 수정은 NOTES.txt와 기타 설정 파일에서 하드코딩된 `/opt/bitnami` 경로 참조를 모두 `/opt/bitmoa`로 변경합니다. 이 변경은 비교적 간단하지만 MariaDB 관리 기능의 정상 작동을 위해 중요합니다.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)