### PR TITLE
[bitmoa/rabbitmq] rabbitmq Erlang bitnami fixed path error

### DIFF
--- a/bitmoa/rabbitmq/Chart.yaml
+++ b/bitmoa/rabbitmq/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: rabbitmq
 sources:
 - https://github.com/bitmoa/charts/tree/main/bitmoa/rabbitmq
-version: 16.0.14
+version: 16.0.15

--- a/bitmoa/rabbitmq/templates/statefulset.yaml
+++ b/bitmoa/rabbitmq/templates/statefulset.yaml
@@ -194,6 +194,8 @@ spec:
                     fi
           {{- end }}
           env:
+            - name: ERL_ROOTDIR
+              value: {{ .Values.global.erlRootPath | quote }}
             - name: BITMOA_DEBUG
               value: {{ ternary "true" "false" (or .Values.image.debug .Values.diagnosticMode.enabled) | quote }}
             - name: MY_POD_IP

--- a/bitmoa/rabbitmq/values.yaml
+++ b/bitmoa/rabbitmq/values.yaml
@@ -35,6 +35,7 @@ global:
       ## @param global.compatibility.openshift.adaptSecurityContext Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation)
       ##
       adaptSecurityContext: auto
+  erlRootPath: "/opt/bitmoa/erlang/lib/erlang/"
 ## @section RabbitMQ Image parameters
 ## Bitnami RabbitMQ image version
 ## ref: https://hub.docker.com/r/bitmoa/rabbitmq/tags/


### PR DESCRIPTION
### Description of the change

RabbitMQ 차트에서 Erlang 경로 오류를 수정하기 위해 StatefulSet 환경 변수에 `ERL_ROOTDIR`를 추가했습니다. `/opt/bitnami`에서 `/opt/bitmoa`로의 경로 변경 과정에서 Erlang 런타임이 여전히 이전 경로를 참조하고 있어 RabbitMQ 시작 과정에서 오류가 발생하는 문제를 해결했습니다.

### Benefits

- Erlang 런타임이 올바른 루트 디렉터리(`/opt/bitmoa`)를 사용하도록 보장
- RabbitMQ 서비스의 안정적인 시작 및 초기화 보장
- "Starting RabbitMQ" 과정에서 발생하던 Erlang 관련 오류 해결
- 컨테이너 재시작 루프 방지 및 서비스 안정성 향상

### Possible drawbacks

- 추가된 환경 변수(`ERL_ROOTDIR`)가 기존 커스텀 설정과 충돌할 가능성이 있습니다.

### Applicable issues

<img width="1895" height="256" alt="image" src="https://github.com/user-attachments/assets/0f625087-8ff1-47de-ac23-1145c44d1e6f" />

### Additional information

로그에서 RabbitMQ 시작 시 Erlang 경로 관련 문제가 확인되었습니다. 이 문제를 해결하기 위해 Kubernetes StatefulSet의 환경 변수 섹션에 다음과 같이 `ERL_ROOTDIR` 환경 변수를 추가하였습니다:

```yaml
env:
  - name: ERL_ROOTDIR
    value: /opt/bitmoa/erlang/lib/erlang/
```


